### PR TITLE
build: do not impose folder names

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,5 +64,5 @@
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "**/*spec.ts"]
 }


### PR DESCRIPTION
Remove `dist` as a folder in tsconfig.json `exclude`. Do not impose dist as the build folder name.