### PR TITLE
chore(github): labels revamp

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
-# Add 'repo' label to any root file changes
-repo:
-  - './*'
+# Add 'pkg' label to any package[-lock].json file changes
+pkg:
+  - package*.json
 
 # Add 'tool-config' label to any change to tool's config files
 tool-config:
@@ -11,6 +11,11 @@ tool-config:
 # Add 'github' label to any change within the github dir
 github:
   - .github/**/*
+ 
+# Add 'docs' label to README, LICENSE (...) file changes
+docs:
+  - README*
+  - LICENSE*
 
 # Add 'src' label to any change to source files within the source dir
 src:


### PR DESCRIPTION
Added 2 labels: `pkg` and `docs` for changes to package[-lock].json and to README and LICENSE files, respectively.

Removed `repo` label since it is too generic.